### PR TITLE
Updated proxy env var passthrough in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ install_command = pip install {opts} {packages}
 passenv =
     HOME
     TERM
-    SNAP_BUILD_PROXY
+    SNAPSTACK_HTTP_PROXY
+    SNAPSTACK_HTTPS_PROXY
 whitelist_externals =
     sudo
     snapcraft


### PR DESCRIPTION
We made a breaking change to snapstack. SNAP_BUILD_PROXY ->
SNAPSTACK_HTTP/S_PROXY.