### PR TITLE
Escaped curly braces in snap.conf.j2 template

### DIFF
--- a/{{cookiecutter.repo_name}}/snap/templates/{{cookiecutter.snap_name}}-snap.conf.j2
+++ b/{{cookiecutter.repo_name}}/snap/templates/{{cookiecutter.snap_name}}-snap.conf.j2
@@ -1,7 +1,7 @@
 [DEFAULT]
 # Set state path to writable directory
-state_path = {{ snap_common }}/lib
+state_path = {{ "{{" }} snap_common {{ "}}" }}/lib
 
 [oslo_concurrency]
 # Oslo Concurrency lock path
-lock_path = {{ snap_common }}/lock
+lock_path = {{ "{{" }} snap_common {{ "}}" }}/lock


### PR DESCRIPTION
Fixes a cookiecutter error.